### PR TITLE
Broaden flicker-fix device list

### DIFF
--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -407,37 +407,19 @@ var LOADING_DELAY = 250;
 /** Devices which are known/expected to flicker if Pixi's `transparent` mode is not enabled */
 var FLICKERERS = [
     //Kindle fire tablets:
-    'KFFOWI',
-    'KFMEWI',
-    'KFTBWI',
-    'KFARWI',
-    'KFASWI',
-    'KFSAWA',
-    'KFSAWI',
-    'KFAPWA',
-    'KFAPWI',
-    'KFTHWA',
-    'KFTHWI',
-    'KFSOWI',
-    'KFJWA',
-    'KFJWI',
-    'KFTT',
-    'KFOT',
-    'Kindle Fire',
-    'Silk',
+    // /KFMUWI/, /KFKAWI/, /KFSUWI/, /KFAUWI/, /KFDOWI/, /KFGIWI/, /KFFOWI/, /KFMEWI/, /KFTBWI/, /KFARWI/, /KFASWI/, /KFSAWA/, /KFSAWI/, /KFAPWA/, /KFAPWI/, /KFTHWA/, /KFTHWI/, /KFSOWI/,
+    /KF..WI/,
+    /KFJWA/,
+    /KFJWI/,
+    /KFTT/,
+    /KFOT/,
+    /Kindle Fire/,
+    /Silk/,
     //Galaxy Tab A 7":
-    'SM-T280',
+    /SM-T280/,
     //RCA tablets:
-    'RCT6077W2',
-    'RCT6103W46',
-    'RCT6203W46',
-    'RCT6272W23',
-    'RCT6303W87',
-    'RCT6378W2',
-    'RCT6773W22',
-    'RCT6773W42',
-    'RCT6873W42',
-    'RCT6973W43',
+    // /RCT6077W2/, /RCT6103W46/, /RCT6203W46/, /RCT6272W23/, /RCT6303W87/, /RCT6378W2/, /RCT6773W22/, /RCT6773W42/, /RCT6873W42/, /RCT6973W43/,
+    /RCT6\d\d\dW\d?\d/
 ];
 var TRANSITION_ID = 'wgbhSpringRollGameTransition';
 /**
@@ -532,7 +514,7 @@ var StageManager = /** @class */ (function () {
         this.offset = new PIXI.Point(0, 0);
         // transparent rendering mode is bad for overall performance, but necessary in order
         // to prevent flickering on some Android devices such as Galaxy Tab A and Kindle Fire
-        var flickerProne = !!FLICKERERS.find(function (value) { return navigator.userAgent.includes(value); });
+        var flickerProne = !!FLICKERERS.find(function (value) { return value.test(navigator.userAgent); });
         this.pixi = new PIXI.Application({ width: width, height: height, antialias: true, transparent: flickerProne });
         this.pixi.view.style.display = 'block';
         document.getElementById(containerID).appendChild(this.pixi.view);

--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -407,10 +407,9 @@ var LOADING_DELAY = 250;
 /** Devices which are known/expected to flicker if Pixi's `transparent` mode is not enabled */
 var FLICKERERS = [
     //Kindle fire tablets:
-    // /KFMUWI/, /KFKAWI/, /KFSUWI/, /KFAUWI/, /KFDOWI/, /KFGIWI/, /KFFOWI/, /KFMEWI/, /KFTBWI/, /KFARWI/, /KFASWI/, /KFSAWA/, /KFSAWI/, /KFAPWA/, /KFAPWI/, /KFTHWA/, /KFTHWI/, /KFSOWI/,
-    /KF..WI/,
-    /KFJWA/,
-    /KFJWI/,
+    // /KFMUWI/, /KFKAWI/, /KFSUWI/, /KFAUWI/, /KFDOWI/, /KFGIWI/, /KFFOWI/, /KFMEWI/, /KFTBWI/, /KFARWI/, /KFASWI/, /KFSAWA/, /KFSAWI/, /KFAPWA/, /KFAPWI/, /KFTHWA/, /KFTHWI/, /KFSOWI/, /KFJWA/, /KFJWI/,
+    /KF.?.WI/,
+    /KF.?.WA/,
     /KFTT/,
     /KFOT/,
     /Kindle Fire/,

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -10,6 +10,12 @@ const LOADING_DELAY = 250;
 /** Devices which are known/expected to flicker if Pixi's `transparent` mode is not enabled */
 const FLICKERERS = [
     //Kindle fire tablets:
+    'KFMUWI',
+    'KFKAWI',
+    'KFSUWI',
+    'KFAUWI',
+    'KFDOWI',
+    'KFGIWI',
     'KFFOWI',
     'KFMEWI',
     'KFTBWI',

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -10,10 +10,9 @@ const LOADING_DELAY = 250;
 /** Devices which are known/expected to flicker if Pixi's `transparent` mode is not enabled */
 const FLICKERERS = [
     //Kindle fire tablets:
-    // /KFMUWI/, /KFKAWI/, /KFSUWI/, /KFAUWI/, /KFDOWI/, /KFGIWI/, /KFFOWI/, /KFMEWI/, /KFTBWI/, /KFARWI/, /KFASWI/, /KFSAWA/, /KFSAWI/, /KFAPWA/, /KFAPWI/, /KFTHWA/, /KFTHWI/, /KFSOWI/,
-    /KF..WI/,
-    /KFJWA/,
-    /KFJWI/,
+    // /KFMUWI/, /KFKAWI/, /KFSUWI/, /KFAUWI/, /KFDOWI/, /KFGIWI/, /KFFOWI/, /KFMEWI/, /KFTBWI/, /KFARWI/, /KFASWI/, /KFSAWA/, /KFSAWI/, /KFAPWA/, /KFAPWI/, /KFTHWA/, /KFTHWI/, /KFSOWI/, /KFJWA/, /KFJWI/,
+    /KF.?.WI/,
+    /KF.?.WA/,
     /KFTT/,
     /KFOT/,
     /Kindle Fire/,

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -10,43 +10,19 @@ const LOADING_DELAY = 250;
 /** Devices which are known/expected to flicker if Pixi's `transparent` mode is not enabled */
 const FLICKERERS = [
     //Kindle fire tablets:
-    'KFMUWI',
-    'KFKAWI',
-    'KFSUWI',
-    'KFAUWI',
-    'KFDOWI',
-    'KFGIWI',
-    'KFFOWI',
-    'KFMEWI',
-    'KFTBWI',
-    'KFARWI',
-    'KFASWI',
-    'KFSAWA',
-    'KFSAWI',
-    'KFAPWA',
-    'KFAPWI',
-    'KFTHWA',
-    'KFTHWI',
-    'KFSOWI',
-    'KFJWA',
-    'KFJWI',
-    'KFTT',
-    'KFOT',
-    'Kindle Fire',
-    'Silk',
+    // /KFMUWI/, /KFKAWI/, /KFSUWI/, /KFAUWI/, /KFDOWI/, /KFGIWI/, /KFFOWI/, /KFMEWI/, /KFTBWI/, /KFARWI/, /KFASWI/, /KFSAWA/, /KFSAWI/, /KFAPWA/, /KFAPWI/, /KFTHWA/, /KFTHWI/, /KFSOWI/,
+    /KF..WI/,
+    /KFJWA/,
+    /KFJWI/,
+    /KFTT/,
+    /KFOT/,
+    /Kindle Fire/,
+    /Silk/,
     //Galaxy Tab A 7":
-    'SM-T280',
+    /SM-T280/,
     //RCA tablets:
-    'RCT6077W2',
-    'RCT6103W46',
-    'RCT6203W46',
-    'RCT6272W23',
-    'RCT6303W87',
-    'RCT6378W2',
-    'RCT6773W22',
-    'RCT6773W42',
-    'RCT6873W42',
-    'RCT6973W43',
+    // /RCT6077W2/, /RCT6103W46/, /RCT6203W46/, /RCT6272W23/, /RCT6303W87/, /RCT6378W2/, /RCT6773W22/, /RCT6773W42/, /RCT6873W42/, /RCT6973W43/,
+    /RCT6\d\d\dW\d?\d/
 ];
 
 
@@ -93,7 +69,7 @@ export default class StageManager{
 
         // transparent rendering mode is bad for overall performance, but necessary in order
         // to prevent flickering on some Android devices such as Galaxy Tab A and Kindle Fire
-        const flickerProne = !!FLICKERERS.find((value) => navigator.userAgent.includes(value));
+        const flickerProne = !!FLICKERERS.find((value) => value.test(navigator.userAgent));
         this.pixi = new PIXI.Application({ width, height, antialias:true, transparent:flickerProne});
         this.pixi.view.style.display = 'block';
 


### PR DESCRIPTION
Missed the latest batch of Kindle Fire models to the flicker-fix list - this adds those.