### PR TITLE
Support asynchrony in Scene preload() and setup()

### DIFF
--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -468,9 +468,14 @@ var StageManager = /** @class */ (function () {
             })
                 .then(function () {
                 _this._currentScene = new NewScene(_this.game);
-                return new Promise(function (resolve) {
-                    _this.game.assetManager.loadAssets(_this._currentScene.preload(), resolve);
-                });
+                return _this._currentScene.preload();
+            })
+                .then(function (assetList) {
+                if (assetList) {
+                    return new Promise(function (resolve) {
+                        _this.game.assetManager.loadAssets(assetList, resolve);
+                    });
+                }
             })
                 .then(function () {
                 return new Promise(function (resolve) {
@@ -478,7 +483,7 @@ var StageManager = /** @class */ (function () {
                 });
             })
                 .then(function () {
-                _this._currentScene.setup();
+                return _this._currentScene.setup();
             })
                 .then(function () {
                 return new Promise(function (resolve) {

--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -1524,8 +1524,9 @@ var Scene = /** @class */ (function (_super) {
         return _this;
     }
     /**
-     * provide list of assets to preload
-     * @returns {AssetList}
+     * Provide list of assets to preload.
+     * Optionally, return a Promise which may return a list of assets to preload.
+     * @returns {AssetList | Promise<AssetList>}
      */
     Scene.prototype.preload = function () {
         return;
@@ -1538,7 +1539,9 @@ var Scene = /** @class */ (function (_super) {
         this.stageManager.changeScene(sceneID);
     };
     /**
-     * prepare initial visual state - called after preload is complete, while scene is obscured by loader
+     * Prepare initial visual state - called after preload is complete, while scene is obscured by loader.
+     * Optionally return a Promise, which will delay removal of the loader until it is resolved.
+     * @returns {Promise<any> | void}
      */
     Scene.prototype.setup = function () {
         //override this, called to prepare graphics

--- a/dts/scenes/Scene.d.ts
+++ b/dts/scenes/Scene.d.ts
@@ -28,8 +28,9 @@ export default class Scene extends PIXI.Container {
     protected readonly app: Application;
     constructor(game: Game);
     /**
-     * provide list of assets to preload
-     * @returns {AssetList}
+     * Provide list of assets to preload.
+     * Optionally, return a Promise which may return a list of assets to preload.
+     * @returns {AssetList | Promise<AssetList>}
      */
     preload(): AssetList | Promise<AssetList>;
     /**
@@ -38,7 +39,9 @@ export default class Scene extends PIXI.Container {
      */
     changeScene(sceneID: string): void;
     /**
-     * prepare initial visual state - called after preload is complete, while scene is obscured by loader
+     * Prepare initial visual state - called after preload is complete, while scene is obscured by loader.
+     * Optionally return a Promise, which will delay removal of the loader until it is resolved.
+     * @returns {Promise<any> | void}
      */
     setup(): Promise<any> | void;
     /**

--- a/dts/scenes/Scene.d.ts
+++ b/dts/scenes/Scene.d.ts
@@ -31,7 +31,7 @@ export default class Scene extends PIXI.Container {
      * provide list of assets to preload
      * @returns {AssetList}
      */
-    preload(): AssetList;
+    preload(): AssetList | Promise<AssetList>;
     /**
      * Exit this Scene and transition to specified scene
      * @param {string} sceneID ID of Scene to transition to
@@ -40,7 +40,7 @@ export default class Scene extends PIXI.Container {
     /**
      * prepare initial visual state - called after preload is complete, while scene is obscured by loader
      */
-    setup(): void;
+    setup(): Promise<any> | void;
     /**
      * entrypoint to scene - called after loader transition is complete
      */

--- a/src/scenes/Scene.ts
+++ b/src/scenes/Scene.ts
@@ -42,8 +42,9 @@ export default class Scene extends PIXI.Container {
     }
 
     /**
-     * provide list of assets to preload
-     * @returns {AssetList}
+     * Provide list of assets to preload.
+     * Optionally, return a Promise which may return a list of assets to preload.
+     * @returns {AssetList | Promise<AssetList>}
      */
     preload(): AssetList | Promise<AssetList>{
         return;
@@ -58,7 +59,9 @@ export default class Scene extends PIXI.Container {
     }
 
     /**
-     * prepare initial visual state - called after preload is complete, while scene is obscured by loader
+     * Prepare initial visual state - called after preload is complete, while scene is obscured by loader.
+     * Optionally return a Promise, which will delay removal of the loader until it is resolved.
+     * @returns {Promise<any> | void}
      */
     setup(): Promise<any> | void{
         //override this, called to prepare graphics

--- a/src/scenes/Scene.ts
+++ b/src/scenes/Scene.ts
@@ -45,7 +45,7 @@ export default class Scene extends PIXI.Container {
      * provide list of assets to preload
      * @returns {AssetList}
      */
-    preload():AssetList {
+    preload(): AssetList | Promise<AssetList>{
         return;
     }
 
@@ -60,7 +60,7 @@ export default class Scene extends PIXI.Container {
     /**
      * prepare initial visual state - called after preload is complete, while scene is obscured by loader
      */
-    setup(){
+    setup(): Promise<any> | void{
         //override this, called to prepare graphics
     }
     

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -170,9 +170,14 @@ export default class StageManager{
             })
             .then(() => {
                 this._currentScene = new NewScene(this.game);
-                return new Promise((resolve)=>{
-                    this.game.assetManager.loadAssets(this._currentScene.preload(), resolve);
-                });
+                return this._currentScene.preload();
+            })
+            .then((assetList)=>{
+                if(assetList){
+                    return new Promise((resolve)=>{
+                        this.game.assetManager.loadAssets(assetList, resolve);
+                    });
+                }
             })
             .then(()=>{
                 return new Promise((resolve)=>{
@@ -180,7 +185,7 @@ export default class StageManager{
                 });
             })
             .then(()=>{
-                this._currentScene.setup();
+                return this._currentScene.setup();
             })
             .then(()=>{
                 return new Promise((resolve)=>{


### PR DESCRIPTION
This change allows returning a Promise in Scenes' `preload()` and `setup()` functions, which can be used to execute any asynchronous code that needs to happen during a Scene transition. This is optional, with no breaking changes.