### PR TITLE
Limit pause commands

### DIFF
--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -1046,8 +1046,10 @@ var Game = /** @class */ (function () {
             _this.sound.voVolume = volume;
         });
         this.app.state.pause.subscribe(function (pause) {
-            pause ? _this.sound.pause() : _this.sound.resume();
-            _this.stageManager.pause = pause;
+            if (_this.stageManager.pause !== pause) {
+                pause ? _this.sound.pause() : _this.sound.resume();
+                _this.stageManager.pause = pause;
+            }
         });
         this.app.state.captionsMuted.subscribe(function (isMuted) {
             _this.stageManager.captionsMuted = isMuted;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -48,8 +48,10 @@ export default class Game {
             this.sound.voVolume = volume;
         });
         this.app.state.pause.subscribe((pause)=>{
-            pause ? this.sound.pause() : this.sound.resume();
-            this.stageManager.pause = pause;
+            if(this.stageManager.pause !== pause){
+                pause ? this.sound.pause() : this.sound.resume();
+                this.stageManager.pause = pause;
+            }
         });
         this.app.state.captionsMuted.subscribe((isMuted:boolean)=> {
             this.stageManager.captionsMuted = isMuted;


### PR DESCRIPTION
Ignore `pause` messages that don't differ from the current state.

There's an issue with Pixi Sound on some platforms (iOS) that causes playing audio to get doubled-up (echoey) if `resume()` is called while it's already playing. This change keeps us from responding to unnecessary pause/resume messages.
