### PR TITLE
support altHeight for cropping game by height

### DIFF
--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -427,7 +427,6 @@ var TRANSITION_ID = 'wgbhSpringRollGameTransition';
 var StageManager = /** @class */ (function () {
     function StageManager(game, containerID, width, height, altWidth, altHeight) {
         var _this = this;
-        // private _originSize:ScreenSize;
         this.transitioning = true;
         this.isPaused = false;
         /** Map of Scenes by Scene IDs */

--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -425,8 +425,9 @@ var TRANSITION_ID = 'wgbhSpringRollGameTransition';
  * Manages rendering and transitioning between Scenes
  */
 var StageManager = /** @class */ (function () {
-    function StageManager(game, containerID, width, height, altWidth) {
+    function StageManager(game, containerID, width, height, altWidth, altHeight) {
         var _this = this;
+        // private _originSize:ScreenSize;
         this.transitioning = true;
         this.isPaused = false;
         /** Map of Scenes by Scene IDs */
@@ -512,6 +513,9 @@ var StageManager = /** @class */ (function () {
         this.gotResize = function (newsize) {
             _this.resize(newsize.width, newsize.height);
         };
+        if (altWidth && altHeight) {
+            console.error('responsive scaling system only supports altWidth OR altHeight, using both will produce undesirable results');
+        }
         this.game = game;
         this.width = width;
         this.height = height;
@@ -524,16 +528,25 @@ var StageManager = /** @class */ (function () {
         document.getElementById(containerID).appendChild(this.pixi.view);
         var baseSize = { width: width, height: height };
         altWidth = altWidth || width;
-        var altSize = { width: altWidth, height: height };
+        altHeight = altHeight || height;
+        var altSize = { width: altWidth, height: altHeight };
+        var altBigger = altWidth > width || altHeight > height;
         var scale = {
-            origin: baseSize,
-            min: (altWidth > width) ? baseSize : altSize,
-            max: (altWidth > width) ? altSize : baseSize
+            min: altBigger ? baseSize : altSize,
+            max: altBigger ? altSize : baseSize
         };
         this.setScaling(scale);
         this.pixi.ticker.add(this.update.bind(this));
         this.scaleManager = new ScaleManager(this.gotResize);
     }
+    Object.defineProperty(StageManager.prototype, "scale", {
+        get: function () {
+            console.warn('scale is deprecated, please reference viewFrame for stage size info');
+            return 1;
+        },
+        enumerable: true,
+        configurable: true
+    });
     StageManager.prototype.addCaptions = function (captionData, renderer) {
         this.captions = new CaptionPlayer(captionData, renderer);
     };
@@ -619,7 +632,7 @@ var StageManager = /** @class */ (function () {
     };
     StageManager.prototype.setScaling = function (scaleconfig) {
         if (scaleconfig.origin) {
-            this._originSize = this.getSize(scaleconfig.origin.width, scaleconfig.origin.height);
+            console.warn('origin is deprecated and will be ignored');
         }
         if (scaleconfig.min) {
             this._minSize = this.getSize(scaleconfig.min.width, scaleconfig.min.height);
@@ -631,44 +644,67 @@ var StageManager = /** @class */ (function () {
     };
     StageManager.prototype.resize = function (width, height) {
         var aspect = width / height;
-        var offset = 0;
-        //let scale;
-        var calcwidth = this._minSize.width;
-        if (aspect > this._maxSize.ratio) {
+        var wideSize = this._maxSize.width > this._minSize.width ? this._maxSize : this._minSize;
+        var tallSize = this._maxSize.height > this._minSize.height ? this._maxSize : this._minSize;
+        var calcwidth;
+        var calcheight;
+        if (aspect > wideSize.ratio) {
             // locked in at max (2:1)
-            this.scale = this._minSize.ratio / this._maxSize.ratio;
-            calcwidth = this._maxSize.width;
+            calcwidth = wideSize.width;
+            calcheight = wideSize.height;
             // these styles could - probably should - be replaced by media queries in CSS
             this.pixi.view.style.height = height + "px";
-            this.pixi.view.style.width = Math.floor(this._maxSize.ratio * height) + "px";
+            this.pixi.view.style.width = Math.floor(wideSize.ratio * height) + "px";
             this.pixi.view.style.margin = '0 auto';
         }
-        else if (aspect < this._minSize.ratio) {
-            this.scale = 1;
-            var viewHeight = Math.floor(width / this._minSize.ratio);
+        else if (aspect < tallSize.ratio) {
+            calcwidth = tallSize.width;
+            calcheight = tallSize.height;
+            var viewHeight = Math.floor(width / tallSize.ratio);
             this.pixi.view.style.height = viewHeight + "px";
             this.pixi.view.style.width = width + "px";
             this.pixi.view.style.margin = Math.floor((height - viewHeight) / 2) + "px 0";
         }
         else {
-            // between min and max ratio (wider than min)
-            this.scale = this._minSize.ratio / aspect;
-            calcwidth = this._minSize.width / this.scale; // how much wider is this?
+            // between min and max ratio
+            if (wideSize.width !== tallSize.width) {
+                var widthDiff = wideSize.width - tallSize.width;
+                var aspectDiff = wideSize.ratio - tallSize.ratio;
+                var diffRatio = (wideSize.ratio - aspect) / aspectDiff;
+                calcwidth = wideSize.width - widthDiff * diffRatio;
+                calcheight = wideSize.height;
+            }
+            else if (tallSize.height !== wideSize.height) {
+                var heightDiff = tallSize.height - wideSize.height;
+                var aspectDiff = wideSize.ratio - tallSize.ratio;
+                var diffRatio = (aspect - tallSize.ratio) / aspectDiff;
+                calcheight = tallSize.height - heightDiff * diffRatio;
+                calcwidth = tallSize.width;
+            }
+            else {
+                calcheight = tallSize.height;
+                calcwidth = wideSize.width;
+            }
             this.pixi.view.style.height = height + "px";
             this.pixi.view.style.width = width + "px";
             this.pixi.view.style.margin = '0';
         }
-        offset = (calcwidth - this._originSize.width) * 0.5; // offset assumes that the upper left on MIN is 0,0 and the center is fixed
-        this.pixi.stage.position.x = offset;
+        var offset = (calcwidth - wideSize.width) * 0.5; // offset assumes that the upper left on MIN is 0,0 and the center is fixed
+        var verticalOffset = (calcheight - tallSize.height) * 0.5;
+        this.offset.x = offset;
+        this.offset.y = verticalOffset;
+        this.pixi.stage.position.copy(this.offset);
         var newframe = {
             left: offset * -1,
             right: calcwidth - offset,
             width: calcwidth,
             center: calcwidth / 2 - offset,
+            verticalCenter: calcheight / 2 - verticalOffset,
             top: 0,
-            bottom: this._minSize.height,
-            height: this._minSize.height,
-            offset: this.offset
+            bottom: calcheight,
+            height: calcheight,
+            offset: this.offset,
+            verticalOffset: verticalOffset
         };
         if (!this.viewFrame) {
             this.viewFrame = new Property(newframe);
@@ -677,12 +713,11 @@ var StageManager = /** @class */ (function () {
             this.viewFrame.value = newframe;
         }
         this.width = calcwidth;
-        this.height = this._minSize.height;
+        this.height = calcheight;
         /* legacy -- should remove */
         this.leftEdge = newframe.left;
         this.rightEdge = newframe.right;
-        this.pixi.renderer.resize(calcwidth, this._minSize.height);
-        this.offset.x = offset;
+        this.pixi.renderer.resize(calcwidth, calcheight);
         if (this._currentScene) {
             this._currentScene.resize(this.width, this.height, this.offset);
         }
@@ -1031,7 +1066,7 @@ var Game = /** @class */ (function () {
         this.sound = new SoundManager();
         this.assetManager = new AssetManager(this.sound);
         this.cache = this.assetManager.cache;
-        this.stageManager = new StageManager(this, options.containerID, options.width, options.height, options.altWidth);
+        this.stageManager = new StageManager(this, options.containerID, options.width, options.height, options.altWidth, options.altHeight);
         this.app = new Application(options.springRollConfig);
         this.app.state.soundVolume.subscribe(function (volume) {
             _this.sound.volume = volume;

--- a/dts/Game.d.ts
+++ b/dts/Game.d.ts
@@ -48,6 +48,8 @@ export interface GameOptions {
     height: number;
     /** alternate width - wider or narrower than base width  */
     altWidth?: number;
+    /** alternate height - taller or shorter than base height  */
+    altHeight?: number;
     /** caption configuration */
     captions?: CaptionParams;
     /** Class of Animate Stage to use for transitions */

--- a/dts/Game.d.ts
+++ b/dts/Game.d.ts
@@ -46,9 +46,9 @@ export interface GameOptions {
     width: number;
     /** target height of game in pixels */
     height: number;
-    /** alternate width - wider or narrower than base width  */
+    /** alternate width - wider or narrower than base width. Cannot be used with altHeight */
     altWidth?: number;
-    /** alternate height - taller or shorter than base height  */
+    /** alternate height - taller or shorter than base height. Cannot be used with altWidth */
     altHeight?: number;
     /** caption configuration */
     captions?: CaptionParams;

--- a/dts/scenes/StageManager.d.ts
+++ b/dts/scenes/StageManager.d.ts
@@ -12,7 +12,6 @@ export default class StageManager {
     pixi: PIXI.Application;
     width: number;
     height: number;
-    scale: number;
     offset: PIXI.PointLike;
     transition: PIXI.animate.MovieClip;
     viewFrame: Property<ViewFrame>;
@@ -22,7 +21,6 @@ export default class StageManager {
     private _currentScene;
     private _minSize;
     private _maxSize;
-    private _originSize;
     private transitioning;
     private isPaused;
     private game;
@@ -30,7 +28,8 @@ export default class StageManager {
     private isCaptionsMuted;
     /** Map of Scenes by Scene IDs */
     private scenes;
-    constructor(game: Game, containerID: string, width: number, height: number, altWidth?: number);
+    readonly scale: number;
+    constructor(game: Game, containerID: string, width: number, height: number, altWidth?: number, altHeight?: number);
     addCaptions(captionData: CaptionData, renderer: IRender): void;
     setCaptionRenderer(renderer: IRender): void;
     addScene(id: string, scene: typeof Scene): void;
@@ -75,6 +74,7 @@ export declare type RectLike = {
     height: number;
 };
 export declare type ScaleConfig = {
+    /** DEPRECATED */
     origin?: RectLike;
     min?: RectLike;
     max?: RectLike;
@@ -85,6 +85,7 @@ export declare type ViewFrame = {
     top: number;
     bottom: number;
     center: number;
+    verticalCenter: number;
     width: number;
     height: number;
     offset: PIXI.PointLike;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -115,9 +115,9 @@ export interface GameOptions {
     width: number;
     /** target height of game in pixels */
     height: number;
-    /** alternate width - wider or narrower than base width  */
+    /** alternate width - wider or narrower than base width. Cannot be used with altHeight */
     altWidth?: number;
-    /** alternate height - taller or shorter than base height  */
+    /** alternate height - taller or shorter than base height. Cannot be used with altWidth */
     altHeight?: number;
     /** caption configuration */
     captions?: CaptionParams;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -32,7 +32,7 @@ export default class Game {
         this.sound = new SoundManager();
         this.assetManager = new AssetManager(this.sound);
         this.cache = this.assetManager.cache;
-        this.stageManager = new StageManager(this, options.containerID, options.width, options.height, options.altWidth);
+        this.stageManager = new StageManager(this, options.containerID, options.width, options.height, options.altWidth, options.altHeight);
 
         this.app = new SpringRoll.Application(options.springRollConfig);
         this.app.state.soundVolume.subscribe((volume)=>{
@@ -117,6 +117,8 @@ export interface GameOptions {
     height: number;
     /** alternate width - wider or narrower than base width  */
     altWidth?: number;
+    /** alternate height - taller or shorter than base height  */
+    altHeight?: number;
     /** caption configuration */
     captions?: CaptionParams;
     /** Class of Animate Stage to use for transitions */

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -45,7 +45,6 @@ export default class StageManager{
 
     private _minSize:ScreenSize;
     private _maxSize:ScreenSize;
-    // private _originSize:ScreenSize;
 
     private transitioning = true;
     private isPaused = false;

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -34,7 +34,6 @@ export default class StageManager{
     public pixi: PIXI.Application;
     public width: number;
     public height: number;
-    public scale:number;
     public offset:PIXI.PointLike; // offset for the x,y origin when resizing
     public transition:PIXI.animate.MovieClip;
     public viewFrame:Property<ViewFrame>;
@@ -46,7 +45,7 @@ export default class StageManager{
 
     private _minSize:ScreenSize;
     private _maxSize:ScreenSize;
-    private _originSize:ScreenSize;
+    // private _originSize:ScreenSize;
 
     private transitioning = true;
     private isPaused = false;
@@ -57,8 +56,15 @@ export default class StageManager{
 
     /** Map of Scenes by Scene IDs */
     private scenes: {[key:string]:typeof Scene} = {};
+    public get scale():number{
+        console.warn('scale is deprecated, please reference viewFrame for stage size info');
+        return 1;
+    }
 
-    constructor(game:Game, containerID:string, width:number, height:number, altWidth?:number){
+    constructor(game:Game, containerID:string, width:number, height:number, altWidth?:number, altHeight?:number){
+        if(altWidth && altHeight){
+            console.error('responsive scaling system only supports altWidth OR altHeight, using both will produce undesirable results');
+        }
         this.game = game;
 
         this.width = width;
@@ -78,11 +84,12 @@ export default class StageManager{
         const baseSize = {width:width,height:height};
 
         altWidth = altWidth || width;
-        const altSize = {width:altWidth,height:height};
+        altHeight = altHeight || height;
+        const altSize = {width:altWidth,height:altHeight};
+        const altBigger = altWidth > width || altHeight > height;
         const scale = {
-            origin:baseSize,
-            min:(altWidth > width) ? baseSize : altSize,
-            max:(altWidth > width) ? altSize : baseSize
+            min:altBigger ? baseSize : altSize,
+            max:altBigger ? altSize : baseSize
         };
         this.setScaling(scale);
 
@@ -250,7 +257,7 @@ export default class StageManager{
 
     setScaling(scaleconfig:ScaleConfig) {
         if(scaleconfig.origin) {
-            this._originSize = this.getSize(scaleconfig.origin.width,scaleconfig.origin.height);
+            console.warn('origin is deprecated and will be ignored');
         }
         if(scaleconfig.min) {
             this._minSize = this.getSize(scaleconfig.min.width,scaleconfig.min.height);
@@ -267,45 +274,67 @@ export default class StageManager{
 
     resize(width:number, height:number) {
         const aspect = width / height;
-        let offset = 0;
-        //let scale;
-        let calcwidth = this._minSize.width;
-        if(aspect > this._maxSize.ratio) {
+        const wideSize = this._maxSize.width > this._minSize.width ? this._maxSize : this._minSize;
+        const tallSize = this._maxSize.height > this._minSize.height ? this._maxSize : this._minSize;
+        let calcwidth:number;
+        let calcheight:number;
+        if(aspect > wideSize.ratio) {
             // locked in at max (2:1)
-            this.scale = this._minSize.ratio/this._maxSize.ratio;
-            calcwidth = this._maxSize.width;
-            
+            calcwidth = wideSize.width;
+            calcheight = wideSize.height;
             // these styles could - probably should - be replaced by media queries in CSS
             this.pixi.view.style.height = `${height}px`;
-            this.pixi.view.style.width = `${Math.floor(this._maxSize.ratio * height)}px`;
+            this.pixi.view.style.width = `${Math.floor(wideSize.ratio * height)}px`;
             this.pixi.view.style.margin = '0 auto';
-        } else if (aspect < this._minSize.ratio) {
-            this.scale = 1;
-            let viewHeight = Math.floor(width / this._minSize.ratio);
+        } else if (aspect < tallSize.ratio) {
+            calcwidth = tallSize.width;
+            calcheight = tallSize.height;
+            let viewHeight = Math.floor(width / tallSize.ratio);
             this.pixi.view.style.height = `${viewHeight}px`;
             this.pixi.view.style.width = `${width}px`;
             this.pixi.view.style.margin = `${Math.floor((height - viewHeight)/2)}px 0`;
         } else {
-            // between min and max ratio (wider than min)
-            this.scale = this._minSize.ratio / aspect;
-            calcwidth = this._minSize.width / this.scale; // how much wider is this?
+            // between min and max ratio
+            if(wideSize.width !== tallSize.width){
+                let widthDiff = wideSize.width - tallSize.width;
+                let aspectDiff = wideSize.ratio - tallSize.ratio;
+                let diffRatio = (wideSize.ratio - aspect) / aspectDiff;
+                calcwidth = wideSize.width - widthDiff * diffRatio;
+                calcheight = wideSize.height;
+            }
+            else if(tallSize.height !== wideSize.height){
+                let heightDiff = tallSize.height - wideSize.height;
+                let aspectDiff = wideSize.ratio - tallSize.ratio;
+                let diffRatio = (aspect - tallSize.ratio) / aspectDiff;
+                calcheight = tallSize.height - heightDiff * diffRatio;
+                calcwidth = tallSize.width;
+            }
+            else{
+                calcheight = tallSize.height;
+                calcwidth = wideSize.width;
+            }
+
 
             this.pixi.view.style.height = `${height}px`;
             this.pixi.view.style.width = `${width}px`;
             this.pixi.view.style.margin = '0';
         }
-        offset = (calcwidth - this._originSize.width) * 0.5; // offset assumes that the upper left on MIN is 0,0 and the center is fixed
-        this.pixi.stage.position.x = offset;
-
+        let offset = (calcwidth - wideSize.width) * 0.5; // offset assumes that the upper left on MIN is 0,0 and the center is fixed
+        let verticalOffset = (calcheight - tallSize.height) * 0.5;
+        this.offset.x = offset;
+        this.offset.y = verticalOffset;
+        this.pixi.stage.position.copy(this.offset);
         const newframe = {
             left: offset * -1,
             right: calcwidth - offset,
             width: calcwidth,
             center: calcwidth / 2 - offset,
+            verticalCenter: calcheight / 2 - verticalOffset,
             top: 0,
-            bottom: this._minSize.height,
-            height: this._minSize.height,
-            offset: this.offset
+            bottom: calcheight,
+            height: calcheight,
+            offset: this.offset,
+            verticalOffset: verticalOffset
         };
         if(!this.viewFrame) {
             this.viewFrame = new Property(newframe);
@@ -314,15 +343,14 @@ export default class StageManager{
         }
 
         this.width = calcwidth;
-        this.height = this._minSize.height;
+        this.height = calcheight;
 
         /* legacy -- should remove */
         this.leftEdge = newframe.left;
         this.rightEdge = newframe.right;
         
-        this.pixi.renderer.resize(calcwidth,this._minSize.height);
+        this.pixi.renderer.resize(calcwidth, calcheight);
 
-        this.offset.x = offset;
         if (this._currentScene) {
           this._currentScene.resize(this.width,this.height,this.offset);
         }
@@ -389,6 +417,7 @@ export type RectLike = {
 };
 
 export type ScaleConfig = {
+    /** DEPRECATED */
     origin?:RectLike,
     min?:RectLike,
     max?:RectLike
@@ -400,6 +429,7 @@ export type ViewFrame = {
     top:number,
     bottom:number,
     center:number,
+    verticalCenter:number,
     width:number,
     height:number,
     offset:PIXI.PointLike

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -56,7 +56,7 @@ export default class StageManager{
     /** Map of Scenes by Scene IDs */
     private scenes: {[key:string]:typeof Scene} = {};
     public get scale():number{
-        console.warn('scale is deprecated, please reference viewFrame for stage size info');
+        console.warn('scale is obsolete, please reference viewFrame for stage size info');
         return 1;
     }
 
@@ -256,7 +256,7 @@ export default class StageManager{
 
     setScaling(scaleconfig:ScaleConfig) {
         if(scaleconfig.origin) {
-            console.warn('origin is deprecated and will be ignored');
+            console.warn('origin is obsolete and will be ignored');
         }
         if(scaleconfig.min) {
             this._minSize = this.getSize(scaleconfig.min.width,scaleconfig.min.height);


### PR DESCRIPTION
Add support for `altHeight` to responsively scale, cropping top and bottom of canvas. Scaling only supports cropping on one axis, using either `altHeight` for y axis or `altWidth` for x axis.