### PR TITLE
Eliminate dependency on Property for update tick

### DIFF
--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -301,11 +301,11 @@ var AssetManager = /** @class */ (function () {
 
 /**
  *
- *  GameTime is a relay singleton that any object can hook into via its SpringRoll Property to get the next tick (gameTick) of the game clock.
+ *  GameTime is a relay singleton that any object can hook into via its static subscribe() method to get the next tick of the game clock.
  *  Its update() should be called on any live tick of the game; determining whether the tick is live (e.g. checking paused) should happen elsewhere.
  *
- *  Call in the game's main tick/update function, using the singleton syntax on the class - GameTime.Instance.update(deltaTime);
- *  Subscribe to changes using singleton syntax on the class - GameTime.Instance.gameTick.subscribe(callbackfunction)
+ *  Call in the game's main tick/update function, using the static method on the class - GameTime.update(deltaTime);
+ *  Subscribe to changes using static method on the class - GameTime.subscribe(callbackfunction)
  *
  */
 var GameTime = /** @class */ (function () {

--- a/dts/timer/GameTime.d.ts
+++ b/dts/timer/GameTime.d.ts
@@ -9,7 +9,21 @@
  */
 import { Property } from "springroll";
 export default class GameTime {
+    static listeners: ((elapsed?: number) => any)[];
+    /**
+     * @deprecated use GameTime.subscribe() and GameTime.unsubscribe() directly instead
+     */
     static gameTick: Property<number>;
     static update(deltaTime: number): void;
+    /**
+     * Adds an update listener
+     * @param {function} callback The listener to call every frame update
+     */
+    static subscribe(callback: (elapsed?: number) => any): void;
+    /**
+     * Removes an update listener
+     * @param {function} callback The listener to unsubscribe.
+     */
+    static unsubscribe(callback: (elapsed?: number) => any): void;
     static destroy(): void;
 }

--- a/dts/timer/GameTime.d.ts
+++ b/dts/timer/GameTime.d.ts
@@ -1,10 +1,10 @@
 /**
  *
- *  GameTime is a relay singleton that any object can hook into via its SpringRoll Property to get the next tick (gameTick) of the game clock.
+ *  GameTime is a relay singleton that any object can hook into via its static subscribe() method to get the next tick of the game clock.
  *  Its update() should be called on any live tick of the game; determining whether the tick is live (e.g. checking paused) should happen elsewhere.
  *
- *  Call in the game's main tick/update function, using the singleton syntax on the class - GameTime.Instance.update(deltaTime);
- *  Subscribe to changes using singleton syntax on the class - GameTime.Instance.gameTick.subscribe(callbackfunction)
+ *  Call in the game's main tick/update function, using the static method on the class - GameTime.update(deltaTime);
+ *  Subscribe to changes using static method on the class - GameTime.subscribe(callbackfunction)
  *
  */
 import { Property } from "springroll";

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-terser": "^3.0.0",
     "rollup-plugin-tslint": "^0.1.38",
     "rollup-plugin-typescript2": "^0.20.1",
-    "springroll": "^2.0.0",
+    "springroll": "^2.3.0",
     "tslib": "^1.9.3",
     "typedoc": "^0.14.2",
     "typescript": "^3.2.2"

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -394,7 +394,7 @@ export default class StageManager{
         if (this.captions) {
             this.captions.update(elapsed/1000); // captions go by seconds, not ms
         }
-        GameTime.gameTick.value = elapsed;
+        GameTime.update(elapsed);
         if (this.transitioning || !this._currentScene){
             return;
         }

--- a/src/timer/GameTime.ts
+++ b/src/timer/GameTime.ts
@@ -1,10 +1,10 @@
 /**
  * 
- *  GameTime is a relay singleton that any object can hook into via its SpringRoll Property to get the next tick (gameTick) of the game clock.
+ *  GameTime is a relay singleton that any object can hook into via its static subscribe() method to get the next tick of the game clock.
  *  Its update() should be called on any live tick of the game; determining whether the tick is live (e.g. checking paused) should happen elsewhere.
  *  
- *  Call in the game's main tick/update function, using the singleton syntax on the class - GameTime.Instance.update(deltaTime);
- *  Subscribe to changes using singleton syntax on the class - GameTime.Instance.gameTick.subscribe(callbackfunction)
+ *  Call in the game's main tick/update function, using the static method on the class - GameTime.update(deltaTime);
+ *  Subscribe to changes using static method on the class - GameTime.subscribe(callbackfunction)
  *  
  */
 import { Property } from "springroll";

--- a/src/timer/GameTime.ts
+++ b/src/timer/GameTime.ts
@@ -11,13 +11,42 @@ import { Property } from "springroll";
 
 
 export default class GameTime {
-    static gameTick: Property<number> = new Property(0);
+
+    static listeners:((elapsed?:number)=>any)[] = [];
+
+    /**
+     * @deprecated use GameTime.subscribe() and GameTime.unsubscribe() directly instead
+     */
+    static gameTick: Property<number> = new Property(0, true);
 
     static update(deltaTime:number){
-       GameTime.gameTick.value = deltaTime;
+        for (let i = 0; i < this.listeners.length; i++) {
+            this.listeners[i](deltaTime);
+        }
+
+        if(GameTime.gameTick.hasListeners){
+            GameTime.gameTick.value = deltaTime;
+        }
+    }
+
+    /**
+     * Adds an update listener
+     * @param {function} callback The listener to call every frame update
+     */
+    static subscribe(callback:(elapsed?:number)=>any) {
+      GameTime.listeners.push(callback);
+    }
+  
+    /**
+     * Removes an update listener
+     * @param {function} callback The listener to unsubscribe.
+     */
+    static unsubscribe(callback:(elapsed?:number)=>any) {
+      GameTime.listeners = GameTime.listeners.filter(listener => listener !== callback);
     }
 
     static destroy(){
+        GameTime.listeners.length = 0;
         GameTime.gameTick.value = null;
     }
 }

--- a/src/timer/PauseableTimer.ts
+++ b/src/timer/PauseableTimer.ts
@@ -23,7 +23,7 @@ export default class PauseableTimer {
         this.onComplete = callback;
         
         this.repeat = loop;
-        GameTime.gameTick.subscribe(this.update);
+        GameTime.subscribe(this.update);
         PauseableTimer.timers.push(this);
     }
 
@@ -87,7 +87,7 @@ export default class PauseableTimer {
         this.reject = null;
         this.targetTime = null;
         this.onComplete = null;
-        GameTime.gameTick.unsubscribe(this.update);
+        GameTime.unsubscribe(this.update);
         PauseableTimer.timers.splice(PauseableTimer.timers.indexOf(this), 1);
     }
 }

--- a/src/tween/Tween.ts
+++ b/src/tween/Tween.ts
@@ -40,7 +40,7 @@ export default class Tween{
             tween.onComplete = options.onComplete;
         }
         Tween.tweens.push(tween);
-        GameTime.gameTick.subscribe(tween.update);
+        GameTime.subscribe(tween.update);
         return tween;
     }
 
@@ -136,7 +136,7 @@ export default class Tween{
     }
 
     destroy(){
-        GameTime.gameTick.unsubscribe(this.update);
+        GameTime.unsubscribe(this.update);
         Tween.tweens.splice(Tween.tweens.indexOf(this), 1);
         this.target = null;
         this.steps = null;


### PR DESCRIPTION
Deprecates and replaces use of SpringRoll `Property` class for update tick. This gives us compatibility with the latest versions of SpringRoll. Requires SpringRoll 2.3.0 or newer. 

Because `GameTime.gameTick` is a public property which could be used in an existing project, instead of removing completely, I've just flagged it as deprecated, and only update it if it's being used.