### PR TITLE
disable antialiasing on broken Safari/iOS

### DIFF
--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -1,4 +1,4 @@
-import { Property, CaptionPlayer, ScaleManager, Application } from 'springroll';
+import { Property, ScaleManager, CaptionPlayer, Application } from 'springroll';
 
 /**
  * Manages loading, caching, and unloading of assets
@@ -449,7 +449,7 @@ var TRANSITION_ID = 'wgbhSpringRollGameTransition';
  * Manages rendering and transitioning between Scenes
  */
 var StageManager = /** @class */ (function () {
-    function StageManager(game, containerID, width, height, altWidth, altHeight) {
+    function StageManager(game) {
         var _this = this;
         this.transitioning = true;
         this.isPaused = false;
@@ -536,10 +536,20 @@ var StageManager = /** @class */ (function () {
         this.gotResize = function (newsize) {
             _this.resize(newsize.width, newsize.height);
         };
+        this.game = game;
+    }
+    Object.defineProperty(StageManager.prototype, "scale", {
+        get: function () {
+            console.warn('scale is obsolete, please reference viewFrame for stage size info');
+            return 1;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    StageManager.prototype.createRenderer = function (containerID, width, height, altWidth, altHeight, playOptions) {
         if (altWidth && altHeight) {
             console.error('responsive scaling system only supports altWidth OR altHeight, using both will produce undesirable results');
         }
-        this.game = game;
         this.width = width;
         this.height = height;
         this.offset = new PIXI.Point(0, 0);
@@ -552,6 +562,15 @@ var StageManager = /** @class */ (function () {
         var cordovaWindow = window;
         if (cordovaWindow.device && cordovaWindow.device.platform === 'iOS' && cordovaWindow.device.version === '15.4.1') {
             badSafari = true;
+        }
+        else if (playOptions && playOptions.cordova && playOptions.platform === 'iOS') {
+            if (playOptions.osVersion) {
+                badSafari = playOptions.osVersion === '15.4.1';
+            }
+            else {
+                //if no osVersion provided by Games App, disable antialiasing on all iOS
+                badSafari = true;
+            }
         }
         this.pixi = new PIXI.Application({ width: width, height: height, antialias: !badSafari, transparent: flickerProne });
         this.pixi.view.style.display = 'block';
@@ -568,15 +587,7 @@ var StageManager = /** @class */ (function () {
         this.setScaling(scale);
         this.pixi.ticker.add(this.update.bind(this));
         this.scaleManager = new ScaleManager(this.gotResize);
-    }
-    Object.defineProperty(StageManager.prototype, "scale", {
-        get: function () {
-            console.warn('scale is obsolete, please reference viewFrame for stage size info');
-            return 1;
-        },
-        enumerable: false,
-        configurable: true
-    });
+    };
     StageManager.prototype.addCaptions = function (captionData, renderer) {
         this.captions = new CaptionPlayer(captionData, renderer);
     };
@@ -1096,8 +1107,28 @@ var Game = /** @class */ (function () {
         this.sound = new SoundManager();
         this.assetManager = new AssetManager(this.sound);
         this.cache = this.assetManager.cache;
-        this.stageManager = new StageManager(this, options.containerID, options.width, options.height, options.altWidth, options.altHeight);
+        this.stageManager = new StageManager(this);
         this.app = new Application(options.springRollConfig);
+        // Wait until playOptions received before creating renderer
+        // Wait until renderer created before creating transition
+        var rendererInitialized = false;
+        var applicationReady = false;
+        var initializeRenderer = function (playOptions) {
+            if (!rendererInitialized) {
+                _this.stageManager.createRenderer(options.containerID, options.width, options.height, options.altWidth, options.altHeight, playOptions);
+                if (applicationReady) {
+                    _this.stageManager.setTransition(options.transition, _this.preloadGlobal);
+                }
+                rendererInitialized = true;
+            }
+        };
+        //If loaded in an iFrame, wait for playOptions from SpringRoll Container
+        if (options.noContainer || window.self === window.top) {
+            initializeRenderer();
+        }
+        else {
+            this.app.state.playOptions.subscribe(initializeRenderer);
+        }
         this.app.state.soundVolume.subscribe(function (volume) {
             _this.sound.volume = volume;
         });
@@ -1120,7 +1151,10 @@ var Game = /** @class */ (function () {
             _this.stageManager.captionsMuted = isMuted;
         });
         this.app.state.ready.subscribe(function () {
-            _this.stageManager.setTransition(options.transition, _this.preloadGlobal);
+            if (rendererInitialized) {
+                _this.stageManager.setTransition(options.transition, _this.preloadGlobal);
+            }
+            applicationReady = true;
         });
         if (options.captions) {
             this.stageManager.addCaptions(options.captions.config, options.captions.display);

--- a/dist/gamelib.js
+++ b/dist/gamelib.js
@@ -394,7 +394,7 @@ var PauseableTimer = /** @class */ (function () {
             }
             return this._promise;
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     PauseableTimer.prototype.pause = function (pause) {
@@ -546,7 +546,14 @@ var StageManager = /** @class */ (function () {
         // transparent rendering mode is bad for overall performance, but necessary in order
         // to prevent flickering on some Android devices such as Galaxy Tab A and Kindle Fire
         var flickerProne = !!FLICKERERS.find(function (value) { return value.test(navigator.userAgent); });
-        this.pixi = new PIXI.Application({ width: width, height: height, antialias: true, transparent: flickerProne });
+        // Does this version of Safari break antialiasing?
+        var badSafari = navigator.userAgent.includes('Safari') && navigator.userAgent.includes('Version/15.4');
+        // For Cordova:
+        var cordovaWindow = window;
+        if (cordovaWindow.device && cordovaWindow.device.platform === 'iOS' && cordovaWindow.device.version === '15.4.1') {
+            badSafari = true;
+        }
+        this.pixi = new PIXI.Application({ width: width, height: height, antialias: !badSafari, transparent: flickerProne });
         this.pixi.view.style.display = 'block';
         document.getElementById(containerID).appendChild(this.pixi.view);
         var baseSize = { width: width, height: height };
@@ -567,7 +574,7 @@ var StageManager = /** @class */ (function () {
             console.warn('scale is obsolete, please reference viewFrame for stage size info');
             return 1;
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     StageManager.prototype.addCaptions = function (captionData, renderer) {
@@ -619,7 +626,7 @@ var StageManager = /** @class */ (function () {
                 this.captions.stop();
             }
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     Object.defineProperty(StageManager.prototype, "pause", {
@@ -640,7 +647,7 @@ var StageManager = /** @class */ (function () {
                 }
             }
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     StageManager.prototype.getSize = function (width, height) {
@@ -818,7 +825,7 @@ var SoundContext = /** @class */ (function () {
                 this.applyVolume(key);
             }
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     Object.defineProperty(SoundContext.prototype, "globalVolume", {
@@ -829,7 +836,7 @@ var SoundContext = /** @class */ (function () {
                 this.applyVolume(key);
             }
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     /**
@@ -955,7 +962,7 @@ var SoundManager = /** @class */ (function () {
             this.vo.globalVolume = volume;
             this.music.globalVolume = volume;
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     Object.defineProperty(SoundManager.prototype, "sfxVolume", {
@@ -963,7 +970,7 @@ var SoundManager = /** @class */ (function () {
         set: function (volume) {
             this.sfx.volume = volume;
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     Object.defineProperty(SoundManager.prototype, "voVolume", {
@@ -971,7 +978,7 @@ var SoundManager = /** @class */ (function () {
         set: function (volume) {
             this.vo.volume = volume;
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     Object.defineProperty(SoundManager.prototype, "musicVolume", {
@@ -979,7 +986,7 @@ var SoundManager = /** @class */ (function () {
         set: function (volume) {
             this.music.volume = volume;
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     /**
@@ -1148,18 +1155,18 @@ var Game = /** @class */ (function () {
 }());
 
 /*! *****************************************************************************
-Copyright (c) Microsoft Corporation. All rights reserved.
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License. You may obtain a copy of the
-License at http://www.apache.org/licenses/LICENSE-2.0
+Copyright (c) Microsoft Corporation.
 
-THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
-MERCHANTABLITY OR NON-INFRINGEMENT.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
 
-See the Apache Version 2.0 License for specific language governing permissions
-and limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
 ***************************************************************************** */
 /* global Reflect, Promise */
 
@@ -1552,7 +1559,7 @@ var Tween = /** @class */ (function () {
             }
             return this._promise;
         },
-        enumerable: true,
+        enumerable: false,
         configurable: true
     });
     Tween.prototype.destroy = function () {

--- a/dts/Game.d.ts
+++ b/dts/Game.d.ts
@@ -56,6 +56,8 @@ export interface GameOptions {
     transition: AnimateStage;
     /** ID of HTML element on your page to add this game's Canvas to */
     containerID: string;
+    /** Set true if this game is made to be run outside of a SpringRoll Container */
+    noContainer?: boolean;
 }
 export declare type CaptionParams = {
     config: SpringRoll.CaptionData;

--- a/dts/scenes/StageManager.d.ts
+++ b/dts/scenes/StageManager.d.ts
@@ -29,7 +29,13 @@ export default class StageManager {
     /** Map of Scenes by Scene IDs */
     private scenes;
     get scale(): number;
-    constructor(game: Game, containerID: string, width: number, height: number, altWidth?: number, altHeight?: number);
+    constructor(game: Game);
+    createRenderer(containerID: string, width: number, height: number, altWidth?: number, altHeight?: number, playOptions?: any & {
+        cordova?: string;
+        platform?: string;
+        model?: string;
+        osVersion?: string;
+    }): void;
     addCaptions(captionData: CaptionData, renderer: IRender): void;
     setCaptionRenderer(renderer: IRender): void;
     addScene(id: string, scene: typeof Scene): void;

--- a/dts/scenes/StageManager.d.ts
+++ b/dts/scenes/StageManager.d.ts
@@ -28,7 +28,7 @@ export default class StageManager {
     private isCaptionsMuted;
     /** Map of Scenes by Scene IDs */
     private scenes;
-    readonly scale: number;
+    get scale(): number;
     constructor(game: Game, containerID: string, width: number, height: number, altWidth?: number, altHeight?: number);
     addCaptions(captionData: CaptionData, renderer: IRender): void;
     setCaptionRenderer(renderer: IRender): void;
@@ -42,8 +42,10 @@ export default class StageManager {
      * @param {string} sceneID ID of Scene to transition to
      */
     changeScene: (newScene: string) => void;
-    captionsMuted: boolean;
-    pause: boolean;
+    get captionsMuted(): boolean;
+    set captionsMuted(muted: boolean);
+    get pause(): boolean;
+    set pause(pause: boolean);
     getSize(width: number, height: number): ScreenSize;
     setScaling(scaleconfig: ScaleConfig): void;
     gotResize: (newsize: ScreenSize) => void;

--- a/dts/sound/SoundContext.d.ts
+++ b/dts/sound/SoundContext.d.ts
@@ -13,9 +13,9 @@ export default class SoundContext {
     private singleCallback;
     constructor(issingle?: boolean);
     /** Context-specific volume */
-    volume: number;
+    set volume(volume: number);
     /** Volume applied to all contexts */
-    globalVolume: number;
+    set globalVolume(volume: number);
     /**
      *
      * @param {PIXI.sound.Sound} sound Sound instance to add

--- a/dts/sound/SoundManager.d.ts
+++ b/dts/sound/SoundManager.d.ts
@@ -14,13 +14,13 @@ export default class SoundManager {
     /** Mapping of which SoundContexts each Sound belongs to, by ID */
     private soundMeta;
     /** Global volume of all SoundContexts */
-    volume: number;
+    set volume(volume: number);
     /** Volume of all sounds in SFX context */
-    sfxVolume: number;
+    set sfxVolume(volume: number);
     /** Volume of all sounds in VO context */
-    voVolume: number;
+    set voVolume(volume: number);
     /** Volume of all sounds in Music context */
-    musicVolume: number;
+    set musicVolume(volume: number);
     /**
      * Add sound to a SoundManager Context
      * @param {Sound} sound Sound instance to add

--- a/dts/timer/PauseableTimer.d.ts
+++ b/dts/timer/PauseableTimer.d.ts
@@ -11,7 +11,7 @@ export default class PauseableTimer {
     private reject;
     constructor(callback: Function, time: number, loop?: boolean);
     static clearTimers(): void;
-    readonly promise: Promise<void>;
+    get promise(): Promise<void>;
     pause(pause: boolean): void;
     reset(deltaTime: number): void;
     update: (deltaTime: number) => void;

--- a/dts/tween/Tween.d.ts
+++ b/dts/tween/Tween.d.ts
@@ -15,7 +15,7 @@ export default class Tween {
     to: (targetValues: any, totalTime: number, ease?: Ease) => this;
     wait: (totalTime: number) => this;
     call: (call: Function) => this;
-    readonly promise: Promise<void>;
+    get promise(): Promise<void>;
     private doComplete;
     update: (elapsed: number) => any;
     destroy(): void;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -32,9 +32,33 @@ export default class Game {
         this.sound = new SoundManager();
         this.assetManager = new AssetManager(this.sound);
         this.cache = this.assetManager.cache;
-        this.stageManager = new StageManager(this, options.containerID, options.width, options.height, options.altWidth, options.altHeight);
+        this.stageManager = new StageManager(this);
 
         this.app = new SpringRoll.Application(options.springRollConfig);
+
+
+        // Wait until playOptions received before creating renderer
+        // Wait until renderer created before creating transition
+        let rendererInitialized = false;
+        let applicationReady = false;
+        const initializeRenderer = (playOptions?:any)=>{
+            if(!rendererInitialized){
+                this.stageManager.createRenderer(options.containerID, options.width, options.height, options.altWidth, options.altHeight, playOptions);
+                if(applicationReady){
+                    this.stageManager.setTransition(options.transition, this.preloadGlobal);
+                }
+                rendererInitialized = true;
+            }
+        };
+
+        //If loaded in an iFrame, wait for playOptions from SpringRoll Container
+        if(options.noContainer || window.self === window.top){
+            initializeRenderer();
+        }
+        else{
+            this.app.state.playOptions.subscribe(initializeRenderer);
+        }
+
         this.app.state.soundVolume.subscribe((volume)=>{
             this.sound.volume = volume;
         });
@@ -58,7 +82,10 @@ export default class Game {
         });
 
         this.app.state.ready.subscribe(() => {
-                this.stageManager.setTransition(options.transition, this.preloadGlobal);
+                if(rendererInitialized){
+                    this.stageManager.setTransition(options.transition, this.preloadGlobal);
+                }
+                applicationReady = true;
             });
 
         if(options.captions) {
@@ -125,6 +152,8 @@ export interface GameOptions {
     transition: AnimateStage;
     /** ID of HTML element on your page to add this game's Canvas to */
     containerID: string;
+    /** Set true if this game is made to be run outside of a SpringRoll Container */
+    noContainer?: boolean;
 }
 
 export type CaptionParams = {

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -82,12 +82,12 @@ export default class StageManager{
         let badSafari = navigator.userAgent.includes('Safari') && navigator.userAgent.includes('Version/15.4');
         // For Cordova:
         let cordovaWindow:Window & {device:{platform:string; version:string;}} = window as any;
-        if(cordovaWindow.device && cordovaWindow.device.platform === 'iOS' && cordovaWindow.device.version === '15.4.1'){
+        if(cordovaWindow.device && cordovaWindow.device.platform === 'iOS' && cordovaWindow.device.version.startsWith('15.4')){
             badSafari = true;
         }
         else if(playOptions && playOptions.cordova && playOptions.platform === 'iOS'){
             if(playOptions.osVersion){
-                badSafari = playOptions.osVersion === '15.4.1';
+                badSafari = playOptions.osVersion.startsWith('15.4');
             }
             else{
                 //if no osVersion provided by Games App, disable antialiasing on all iOS

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -74,7 +74,16 @@ export default class StageManager{
         // transparent rendering mode is bad for overall performance, but necessary in order
         // to prevent flickering on some Android devices such as Galaxy Tab A and Kindle Fire
         const flickerProne = !!FLICKERERS.find((value) => value.test(navigator.userAgent));
-        this.pixi = new PIXI.Application({ width, height, antialias:true, transparent:flickerProne});
+
+        // Does this version of Safari break antialiasing?
+        let badSafari = navigator.userAgent.includes('Safari') && navigator.userAgent.includes('Version/15.4');
+        // For Cordova:
+        let cordovaWindow:Window & {device:{platform:string; version:string;}} = window as any;
+        if(cordovaWindow.device && cordovaWindow.device.platform === 'iOS' && cordovaWindow.device.version === '15.4.1'){
+            badSafari = true;
+        }
+
+        this.pixi = new PIXI.Application({ width, height, antialias:!badSafari, transparent:flickerProne});
         this.pixi.view.style.display = 'block';
 
 

--- a/src/scenes/StageManager.ts
+++ b/src/scenes/StageManager.ts
@@ -60,11 +60,14 @@ export default class StageManager{
         return 1;
     }
 
-    constructor(game:Game, containerID:string, width:number, height:number, altWidth?:number, altHeight?:number){
+    constructor(game:Game){
+        this.game = game;
+    }
+
+    createRenderer(containerID:string, width:number, height:number, altWidth?:number, altHeight?:number, playOptions?:any & {cordova?:string, platform?:string, model?:string, osVersion?:string}){
         if(altWidth && altHeight){
             console.error('responsive scaling system only supports altWidth OR altHeight, using both will produce undesirable results');
         }
-        this.game = game;
 
         this.width = width;
         this.height = height;
@@ -81,6 +84,15 @@ export default class StageManager{
         let cordovaWindow:Window & {device:{platform:string; version:string;}} = window as any;
         if(cordovaWindow.device && cordovaWindow.device.platform === 'iOS' && cordovaWindow.device.version === '15.4.1'){
             badSafari = true;
+        }
+        else if(playOptions && playOptions.cordova && playOptions.platform === 'iOS'){
+            if(playOptions.osVersion){
+                badSafari = playOptions.osVersion === '15.4.1';
+            }
+            else{
+                //if no osVersion provided by Games App, disable antialiasing on all iOS
+                badSafari = true;
+            }
         }
 
         this.pixi = new PIXI.Application({ width, height, antialias:!badSafari, transparent:flickerProne});


### PR DESCRIPTION
We recently discovered some issues with Pixi in iOS 15.4.1. If antialiasing is enabled, rendering is broken to the point of games being completely unplayable. A fix to WebKit is coming from Apple, but who knows when the next version of iOS will be released (and how quickly users will install the update).
https://developer.apple.com/forums/thread/700924
https://github.com/pixijs/pixijs/issues/8183
https://bugs.webkit.org/show_bug.cgi?id=238022

This change detects the specific version known to have an issue, to disable antialiasing just on that platform.

NOTE: When inside of Cordova, the detection will not work until after the `"deviceready"` event has fired. I expect this should not cause issues for the PBS Kids Games App (testing needed), but for standalone apps, the `Game` constructor should not be run until `"deviceready"` has fired.